### PR TITLE
Staying at loam_mapping_ws/ to colcon build

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ using the below commands for using.
 mkdir -p loam_mapping_ws/src
 cd loam_mapping_ws/src
 git clone https://github.com/ataparlar/loam-mapper
-cd ../..
+cd ../
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ using the below commands for using.
 mkdir -p loam_mapping_ws/src
 cd loam_mapping_ws/src
 git clone https://github.com/ataparlar/loam-mapper
-cd ../
+cd ../..
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 


### PR DESCRIPTION
`cd ../` (instead of `cd../../`) to stay at `loam_mapping_ws` before `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release`